### PR TITLE
feat: add check test framework definitions

### DIFF
--- a/src/main/java/de/friday/sonarqube/gosu/plugin/checks/AbstractCheckBase.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/checks/AbstractCheckBase.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.sonarqube.gosu.plugin.checks;
+
+import de.friday.sonarqube.gosu.antlr.GosuParserBaseListener;
+import org.sonar.api.rule.RuleKey;
+import static de.friday.sonarqube.gosu.language.GosuLanguage.REPOSITORY_KEY;
+
+/**
+ * Base class for all Gosu Sonarqube checks.
+ */
+public abstract class AbstractCheckBase extends GosuParserBaseListener {
+
+    /**
+     * @return Check Key
+     */
+    protected abstract String getKey();
+
+    /**
+     * Returns Check specific Rule Key
+     * Used to associate with Check description
+     *
+     * @return Check Rule Key
+     */
+    public RuleKey getRuleKey() {
+        return RuleKey.of(REPOSITORY_KEY, getKey());
+    }
+
+}

--- a/src/test/java/de/friday/test/support/checks/dsl/specification/CheckRunner.java
+++ b/src/test/java/de/friday/test/support/checks/dsl/specification/CheckRunner.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.test.support.checks.dsl.specification;
+
+/**
+ *
+ * Runs Sonarqube Checks.
+ *
+ * @param <I> type returned by the Check.
+ */
+public interface CheckRunner<I> {
+
+    /**
+     *
+     * Execute a Sonarqube Check.
+     *
+     * @return output from the Check execution.
+     */
+    I executeCheck();
+
+}

--- a/src/test/java/de/friday/test/support/checks/dsl/specification/CheckSpecification.java
+++ b/src/test/java/de/friday/test/support/checks/dsl/specification/CheckSpecification.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.test.support.checks.dsl.specification;
+
+import de.friday.sonarqube.gosu.plugin.checks.AbstractCheckBase;
+
+/**
+ * Defines the basic specification for a Check test.
+ *
+ */
+public interface CheckSpecification extends CheckRunner {
+
+    /**
+     *
+     * Specify the source code file to be analysed by the Check.
+     * <p>
+     * E.g.
+     * <pre>
+     * given(new SourceCodeFile("TODOsCheck/ok.gs")).whenCheckedAgainst(TODOsCheck.class).then().issuesFound().areEmpty();
+     * </pre>
+     * This runs the TODOsCheck against the ok.gs source code file and return the list of issues found.
+     * </p>
+     * @param sourceCodeFile Source code file to run the check against
+     * @return The Check specification
+     */
+    CheckSpecification given(SourceCodeFile sourceCodeFile);
+
+    /**
+     *
+     * Specify the source code file to be analysed by the Check.
+     * <p>
+     * E.g.
+     * <pre>
+     * given("TODOsCheck/nok.gs").whenCheckedAgainst(TODOsCheck.class).then().issuesFound().hasSizeEqualTo(5);
+     * </pre>
+     * This runs the TODOsCheck against the nok.gs source code file and return the list of issues found.
+     * </p>
+     * @param sourceCodeFileName Source code file name to run the check against
+     * @return The Check specification
+     */
+    CheckSpecification given(String sourceCodeFileName);
+
+    /**
+     *
+     * Specify the Check that it be used to run the analyses on the source code file.
+     * <p>
+     * E.g.
+     * <pre>
+     * given("TODOsCheck/ok.gs").whenCheckedAgainst(TODOsCheck.class).then().issuesFound().areEmpty();
+     * </pre>
+     * This runs the TODOsCheck against the ok.gs source code file and return the list of issues found.
+     * </p>
+     * @param checkClass Source code file to run the check against
+     * @return The Check specification
+     */
+    CheckSpecification whenCheckedAgainst(Class<? extends AbstractCheckBase> checkClass);
+
+    /**
+     * Returns the issue specification so that you can set up the expectations on the issues returned by the Check.
+     * E.g.
+     * <pre>
+     * given("TODOsCheck/ok.gs").whenCheckedAgainst(TODOsCheck.class).then().issuesFound().areEmpty();g
+     * </pre>
+     *
+     * @return The issue specificaiton
+     */
+    IssueSpecification then();
+
+}

--- a/src/test/java/de/friday/test/support/checks/dsl/specification/IssueSpecification.java
+++ b/src/test/java/de/friday/test/support/checks/dsl/specification/IssueSpecification.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.test.support.checks.dsl.specification;
+
+public interface IssueSpecification {
+
+    /**
+     * Syntactic sugar to enable expressive issue expectations.
+     * E.g.
+     * <pre>
+     * given("TODOsCheck/ok.gs")
+     * .whenCheckedAgainst(TODOsCheck.class)
+     * .then()
+     * .issuesFound()
+     * .hasSizeEqualTo(5);
+     * .and()
+     * .areLocatedOn(expectedLocations);
+     * </pre>
+     *
+     * @return The Issue specification
+     */
+    IssueSpecification and();
+
+    /**
+     * Syntactic sugar to enable expressive issue expectations.
+     * E.g.
+     * <pre>
+     * given("TODOsCheck/ok.gs").whenCheckedAgainst(TODOsCheck.class).then().issuesFound().areEmpty();
+     * </pre>
+     *
+     * @return The Issue specification
+     */
+    IssueSpecification issuesFound();
+
+    /**
+     * Syntactic sugar to enable expressive issue expectations.
+     * The following expression
+     * <pre>
+     * given("TODOsCheck/ok.gs").whenCheckedAgainst(TODOsCheck.class).then().noIssuesFound();
+     * </pre>
+     * has the same effect as:
+     * <pre>
+     * given("TODOsCheck/ok.gs").whenCheckedAgainst(TODOsCheck.class).then().issuesFound().areEmpty();
+     * </pre>
+     * @return The Issue specification
+     */
+    IssueSpecification noIssuesFound();
+
+    /**
+     * Evaluate if there were no issues found by the Check.
+     * @return The Issue specification
+     */
+    IssueSpecification areEmpty();
+
+    /**
+     * Evaluate if the list of issues found by the Check is equal to the expectation.
+     * E.g.
+     * <pre>
+     * given("TODOsCheck/ok.gs").whenCheckedAgainst(TODOsCheck.class).then().issuesFound().hasSizeEqualTo(10);
+     * </pre>
+     * @return The Issue specification
+     */
+    IssueSpecification hasSizeEqualTo(int expectedNumberOfIssues);
+
+    /**
+     * Evaluate if the list of issues found by the Check are located on the expected text locations on the Source code file.
+     * E.g.
+     * <pre>
+     * given("TODOsCheck/ok.gs")
+     *      .whenCheckedAgainst(TODOsCheck.class)
+     *      .then()
+     *      .issuesFound()
+     *      .areLocatedOn(expectedTextLocations);
+     * </pre>
+     * @return The Issue specification
+     */
+    IssueSpecification areLocatedOn(TextLocations locations);
+
+}

--- a/src/test/java/de/friday/test/support/checks/dsl/specification/SourceCodeFile.java
+++ b/src/test/java/de/friday/test/support/checks/dsl/specification/SourceCodeFile.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.test.support.checks.dsl.specification;
+
+import org.sonar.api.batch.fs.InputFile;
+
+/**
+ * The source code file to test the check against.
+ */
+public interface SourceCodeFile {
+
+    /**
+     * Returns this SourceCodeFile to a Sonar InputFile.
+     *
+     * @return this source file as a InputFile
+     */
+    InputFile asInputFile();
+
+}

--- a/src/test/java/de/friday/test/support/checks/dsl/specification/TextLocations.java
+++ b/src/test/java/de/friday/test/support/checks/dsl/specification/TextLocations.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.test.support.checks.dsl.specification;
+
+import java.util.List;
+import org.sonar.api.batch.fs.TextRange;
+
+/**
+ * The specific locations of a text in a Source file.
+ */
+public interface TextLocations {
+    /**
+     * Translate these locations in a list of Sonar TextRange objects.
+     *
+     * @return this TextLocations as a list of TextRange
+     */
+    List<TextRange> get();
+}


### PR DESCRIPTION
Overview
-------------------------
This pull request adds a specification for a DSL to write tests for Checks in a fluent manner.

The target is to have an implementation of the DSL spec that enables easy-to-write, easy-to-read tests for Gosu Checks. 

E.g.:
```java
class SomeCheckTest {

  @Test
  void findsNoIssuesWhenGosuCodeIsComplaint() {
     given("SomeCheck/MyGosuSourceCodeFile.gs")
                .whenCheckedAgainst(SomeCheck.class)
                .then().issuesFound().areEmpty();
  }

     @Test
  void findsIssuesWhenGosuCodeIsNotComplaint() {
     given("SomeCheck/NonComplaintGosuCode.gs")
                .whenCheckedAgainst(SomeCheck.class)
                .then()
                .issuesFound()
                .hasSizeEqualTo(2)
                .and()
                .areLocatedOn(
                        TextLocations.of(
                                Arrays.asList(9, 7, 9, 12),
                                Arrays.asList(11, 7, 11, 12)
                        )
                );
    }
}

```


 