### PR TITLE
tech-debit: refactor empty string match on MagicNumbersRule

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,6 +19,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
+- [ ] Tech Debit (refactoring, etc.)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Documentation (add or update README or docs)
 

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/MagicNumbersRule.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/MagicNumbersRule.java
@@ -36,7 +36,7 @@ public class MagicNumbersRule extends BaseGosuRule {
     private static final int TWO_LETTERS_SUFFIX_LENGTH = 2;
     private static final String DEFAULT_NUMBERS = "-1,0,1";
     @SuppressWarnings("squid:S4784")
-    private static final Pattern FLOATING_POINT_PATTERN = Pattern.compile("[+-]?([0-9]*)?[.]0+([a-zA-Z])?");
+    private static final Pattern FLOATING_POINT_PATTERN = Pattern.compile("[+-]?([\\d]+)?[.]0+([a-zA-Z])?");
     @RuleProperty(
             key = "Authorized numbers",
             description = "Comma separated list of authorized numbers. Example: -1,0,1,2",

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/MagicNumbersRuleTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/MagicNumbersRuleTest.java
@@ -31,7 +31,7 @@ class MagicNumbersRuleTest {
     }
 
     @Test
-    void findsNoIssuesWhenMagicNumbersAreFound() {
+    void findsIssuesWhenMagicNumbersAreFound() {
         given("MagicNumbersRule/nok.gs")
                 .whenCheckedAgainst(MagicNumbersRule.class)
                 .then().issuesFound().hasSizeEqualTo(8)


### PR DESCRIPTION
## Description
Refactor Regex to avoid matching empty String.

## Motivation and Context
Address issue caught by Sonar.

## Screenshots (if appropriate):

- Before
![regex-empty-string-issue](https://user-images.githubusercontent.com/4359233/224952654-70524979-3231-457d-be46-e3fbe9e4a5a0.png)

- After:
![magic-numbers-rule](https://user-images.githubusercontent.com/4359233/224953013-0bfdef53-d075-4c1d-a5ca-4495642b0855.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [x]  Tech Debit (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
