### PR TITLE
tech-debit: remove unnecessary public modifiers from test classes

### DIFF
--- a/src/test/java/de/friday/sonarqube/gosu/GosuPluginTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/GosuPluginTest.java
@@ -28,11 +28,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class GosuPluginTest {
+class GosuPluginTest {
 
     @ParameterizedTest
     @EnumSource(SonarServerVersionSupported.class)
-    public void shouldAddGosuExtensionsToSonarServer(SonarServerVersionSupported sonarServerVersion) {
+    void shouldAddGosuExtensionsToSonarServer(SonarServerVersionSupported sonarServerVersion) {
         // given
         final SonarRuntime runtime = SonarRuntimeImpl.forSonarQube(sonarServerVersion.getVersion(), SonarQubeSide.SERVER);
         final Plugin.Context context = new Plugin.Context(runtime);

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/measures/metrics/TestsMetricTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/measures/metrics/TestsMetricTest.java
@@ -24,7 +24,7 @@ import org.sonar.api.measures.CoreMetrics;
 import static de.friday.test.support.TestResourcesDirectories.METRICS_RESOURCES_DIR;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class TestsMetricTest {
+class TestsMetricTest {
 
     @Test
     void shouldSaveCoreTestMetricsOnSensorContext() {

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/RuleTypeTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/RuleTypeTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class RuleTypeTest {
+class RuleTypeTest {
 
     @ParameterizedTest(name = "should return package {1} rule keys for CheckType {0}")
     @MethodSource("checkTypesAndRuleKeysCount")

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/bugs/SystemClockUnawareDateRuleTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/bugs/SystemClockUnawareDateRuleTest.java
@@ -19,7 +19,7 @@ package de.friday.sonarqube.gosu.plugin.rules.bugs;
 import org.junit.jupiter.api.Test;
 import static de.friday.test.support.rules.dsl.gosu.GosuRuleTestDsl.given;
 
-public class SystemClockUnawareDateRuleTest {
+class SystemClockUnawareDateRuleTest {
 
     @Test
     void findsIssuesWhenDateIsCreatedUnawareOfSystemClock() {

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
@@ -21,7 +21,7 @@ import static de.friday.test.support.rules.dsl.gosu.GosuRuleTestDsl.given;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-public class UnnecessaryImportRuleTest {
+class UnnecessaryImportRuleTest {
 
     @Test
     void findsNoIssuesWhenNoUnnecessaryImportIsFound() {

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/tools/listeners/SyntaxErrorListenerTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/tools/listeners/SyntaxErrorListenerTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SyntaxErrorListenerTest {
+class SyntaxErrorListenerTest {
 
     private static final Path LISTENERS_TEST_RESOURCES_DIR = Paths.get("src/test/resources/listeners");
 

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/tools/reflections/RulesKeysExtractorTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/tools/reflections/RulesKeysExtractorTest.java
@@ -20,7 +20,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RulesKeysExtractorTest {
+class RulesKeysExtractorTest {
 
     @Test
     void shouldReturnPackageOfRule() {


### PR DESCRIPTION
## Description
Removes unnecessary `public` modifiers from test classes.

## Motivation and Context
Fix Sonar issue as [this](https://sonarcloud.io/project/issues?open=AYbaeORTLE_jwopVrr0U&id=FRI-DAY_sonar-gosu-plugin) one.

## Screenshots (if appropriate):
- Before:
![before](https://user-images.githubusercontent.com/4359233/224781898-59b58e44-68af-4b1e-9f22-f928f537ec44.png)

- After:
![syntax-error-listernet-test](https://user-images.githubusercontent.com/4359233/224965806-f3d75c08-3376-4c5d-8013-0d34fd5953cc.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Tech Debit (refactoring, etc.) 
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
