### PR TITLE
tech-debit: use method reference on UnnecessaryImportRule filter

### DIFF
--- a/src/main/java/de/friday/sonarqube/gosu/plugin/measures/tools/GosuHighlighting.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/measures/tools/GosuHighlighting.java
@@ -19,6 +19,7 @@ package de.friday.sonarqube.gosu.plugin.measures.tools;
 import de.friday.sonarqube.gosu.antlr.GosuLexer;
 import de.friday.sonarqube.gosu.plugin.GosuFileProperties;
 import de.friday.sonarqube.gosu.plugin.utils.TextRangeUtil;
+import org.antlr.v4.runtime.Recognizer;
 import org.antlr.v4.runtime.Token;
 import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.sensor.highlighting.NewHighlighting;
@@ -31,7 +32,7 @@ public final class GosuHighlighting {
 
     public static void highlightToken(Token token, NewHighlighting highlighting, GosuFileProperties gosuFileProperties) {
         switch (token.getType()) {
-            case GosuLexer.EOF:
+            case Recognizer.EOF:
             case GosuLexer.IDENTIFIER:
                 break;
             case GosuLexer.LINE_COMMENT:

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
@@ -62,7 +62,7 @@ public class UnnecessaryImportRule extends BaseGosuRule {
     public void exitUsesFeatureLiteral(GosuParser.UsesFeatureLiteralContext context) {
         final List<String> staticImportClasses = context.children.stream()
                 .map(ParseTree::getPayload)
-                .filter(currentPackage -> currentPackage instanceof ParserRuleContext)
+                .filter(ParserRuleContext.class::isInstance)
                 .map(parserRuleContext -> ((ParserRuleContext) parserRuleContext).getText())
                 .collect(Collectors.toList());
         allReferencedClasses.addAll(staticImportClasses);

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/measures/MeasuresTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/measures/MeasuresTest.java
@@ -22,7 +22,6 @@ import de.friday.test.support.GosuTestFileParser;
 import de.friday.test.support.GosuTestFileParser.GosuFileParsed;
 import de.friday.test.support.TestResourcesDirectories;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Stream;
 import org.antlr.v4.runtime.CommonTokenStream;

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
@@ -46,8 +46,12 @@ class UnnecessaryImportRuleTest {
 
     @Test
     void getClassNameThrowsExceptionWhenNoPackageIsProvided() {
+        //given
+        final UnnecessaryImportRule rule = new UnnecessaryImportRule();
+
+        //when //then
         assertThatThrownBy(
-                () -> new UnnecessaryImportRule().getClassName("JustClassName")
+                () -> rule.getClassName("JustClassName")
         ).isInstanceOf(IllegalArgumentException.class).hasMessage("No package found.");
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the pull request Title above -->

## Description
<!--- Describe your changes in detail -->
Use method reference on the static imports filter to avoid shadowing the internal variable 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [x] Tech Debit (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
