### PR TITLE
tech-debt: remove direct usages of DefaultTextPointer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
-- [ ] Tech Debit (refactoring, etc.)
+- [ ] Tech Debt (refactoring, etc.)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Documentation (add or update README or docs)
 

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/GosuSensor.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/GosuSensor.java
@@ -31,7 +31,6 @@ import javax.annotation.Nonnull;
 import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.fs.internal.DefaultTextPointer;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
@@ -137,7 +136,7 @@ public class GosuSensor implements Sensor {
         } catch (IOException e) {
             context.newAnalysisError()
                     .onFile(inputFile)
-                    .at(new DefaultTextPointer(0, 0))
+                    .at(inputFile.newPointer(0, 0))
                     .message(e.getMessage())
                     .save();
             LOG.error("Couldn't get input stream from file " + inputFile.filename(), e);

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/tools/listeners/SyntaxErrorListener.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/tools/listeners/SyntaxErrorListener.java
@@ -21,24 +21,25 @@ import de.friday.sonarqube.gosu.plugin.GosuFileProperties;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.RecognitionException;
 import org.antlr.v4.runtime.Recognizer;
-import org.sonar.api.batch.fs.internal.DefaultTextPointer;
+import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 
 public class SyntaxErrorListener extends BaseErrorListener {
     private final SensorContext context;
-    private final GosuFileProperties gosuFileProperties;
+
+    private final InputFile inputFile;
 
     @Inject
     public SyntaxErrorListener(SensorContext context, GosuFileProperties gosuFileProperties) {
         this.context = context;
-        this.gosuFileProperties = gosuFileProperties;
+        this.inputFile = gosuFileProperties.getFile();
     }
 
     @Override
     public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int charPositionInLine, String msg, RecognitionException e) {
         context.newAnalysisError()
-                .onFile(gosuFileProperties.getFile())
-                .at(new DefaultTextPointer(line, charPositionInLine))
+                .onFile(inputFile)
+                .at(inputFile.newPointer(line, charPositionInLine))
                 .message(msg)
                 .save();
     }

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/utils/TextRangeUtil.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/utils/TextRangeUtil.java
@@ -20,13 +20,13 @@ import de.friday.sonarqube.gosu.antlr.GosuLexer;
 import de.friday.sonarqube.gosu.language.utils.GosuUtil;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.sonar.api.batch.fs.TextPointer;
 import org.sonar.api.batch.fs.TextRange;
-import org.sonar.api.batch.fs.internal.DefaultTextPointer;
 import org.sonar.api.batch.fs.internal.DefaultTextRange;
 
 public final class TextRangeUtil {
@@ -54,19 +54,17 @@ public final class TextRangeUtil {
     }
 
     public static TextRange fromPosition(int startLine, int startOffset, int stopLine, int stopOffset) {
-        TextPointer start = new DefaultTextPointer(startLine, startOffset);
-        TextPointer stop = new DefaultTextPointer(stopLine, stopOffset);
+        final TextPointer start = new InternalTextPointer(startLine, startOffset);
+        final TextPointer stop = new InternalTextPointer(stopLine, stopOffset);
 
         return fromPointers(start, stop);
     }
 
     public static TextRange fromTokens(Token startToken, Token endToken) {
-        TextPointer start = new DefaultTextPointer(startToken.getLine(), startToken.getCharPositionInLine());
-
-
-        TextPointer stop = endToken.getType() == GosuLexer.COMMENT
+        final TextPointer start = new InternalTextPointer(startToken.getLine(), startToken.getCharPositionInLine());
+        final TextPointer stop = endToken.getType() == GosuLexer.COMMENT
                 ? fromToken(endToken).end()
-                : new DefaultTextPointer(endToken.getLine(), endToken.getCharPositionInLine() + endToken.getText().length());
+                : new InternalTextPointer(endToken.getLine(), endToken.getCharPositionInLine() + endToken.getText().length());
 
         return fromPointers(start, stop);
     }
@@ -88,8 +86,8 @@ public final class TextRangeUtil {
 
     private static TextRange getMultilineTokenTextRange(Token token) {
         List<String> listOfLines = Arrays.asList(LINE_SEPARATOR.split(token.getText()));
-        TextPointer start = new DefaultTextPointer(token.getLine(), token.getCharPositionInLine());
-        TextPointer stop = getEndTextPointerForMultilineToken(token, listOfLines);
+        final TextPointer start = new InternalTextPointer(token.getLine(), token.getCharPositionInLine());
+        final TextPointer stop = getEndTextPointerForMultilineToken(token, listOfLines);
         return TextRangeUtil.fromPointers(start, stop);
     }
 
@@ -100,7 +98,7 @@ public final class TextRangeUtil {
         if (lastLineIndex == 0) {
             lastLineLength += token.getCharPositionInLine();
         }
-        return new DefaultTextPointer(token.getLine() + lastLineIndex,
+        return new InternalTextPointer(token.getLine() + lastLineIndex,
                 lastLineLength);
     }
 
@@ -110,5 +108,54 @@ public final class TextRangeUtil {
         } else {
             return token.getCharPositionInLine() + token.getText().length();
         }
+    }
+
+    private static class InternalTextPointer implements TextPointer {
+
+        private final int line;
+        private final int lineOffset;
+
+        public InternalTextPointer(int line, int lineOffset) {
+            this.line = line;
+            this.lineOffset = lineOffset;
+        }
+
+        @Override
+        public int line() {
+            return line;
+        }
+
+        @Override
+        public int lineOffset() {
+            return lineOffset;
+        }
+
+        @Override
+        public String toString() {
+            return "[line=" + line + ", lineOffset=" + lineOffset + "]";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TextPointer)) {
+                return false;
+            }
+            final TextPointer other = (TextPointer) obj;
+            return other.line() == this.line && other.lineOffset() == this.lineOffset;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.line, this.lineOffset);
+        }
+
+        @Override
+        public int compareTo(TextPointer o) {
+            if (this.line == o.line()) {
+                return Integer.compare(this.lineOffset, o.lineOffset());
+            }
+            return Integer.compare(this.line, o.line());
+        }
+
     }
 }

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/GosuSensorTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/GosuSensorTest.java
@@ -22,7 +22,18 @@ import de.friday.test.support.TestResourcesDirectories;
 import de.friday.test.support.rules.dsl.gosu.GosuSourceCodeFile;
 import de.friday.test.support.rules.dsl.specification.SourceCodeFile;
 import de.friday.test.support.sonar.scanner.FileLinesContextFactorySpy;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.TextPointer;
+import org.sonar.api.batch.fs.TextRange;
+import org.sonar.api.batch.fs.internal.DefaultTextPointer;
 import org.sonar.api.batch.sensor.internal.DefaultSensorDescriptor;
 import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.scan.filesystem.PathResolver;
@@ -88,6 +99,27 @@ class GosuSensorTest {
         assertThat(sensorDescriptor.languages()).containsExactly(GosuLanguage.KEY);
     }
 
+    @Test
+    void shouldSaveAnalysisErrorOnContextWhenInputFileCanNotBeRead() {
+        // given
+        final InputFile throwingInputFile = new ThrowingInputFile();
+        final SensorContextTester sensorContextTester = createSensorContextTesterFor(new ThrowingInputFile(), false);
+        final GosuSensor sensor = newGosuSensorFor(sensorContextTester);
+
+        // when
+        sensor.execute(sensorContextTester);
+
+        // then
+        assertThat(sensorContextTester.allAnalysisErrors()).hasSize(1).allSatisfy(
+                analysisError -> {
+                    assertThat(analysisError.inputFile().filename()).isEqualTo(throwingInputFile.filename());
+                    assertThat(analysisError.location().line()).isZero();
+                    assertThat(analysisError.location().lineOffset()).isZero();
+                    assertThat(analysisError.message()).isEqualTo("Something exploded!!!");
+                }
+        );
+    }
+
     private GosuSensor newGosuSensorFor(SensorContextTester sensorContextTester) {
         return new GosuSensor(
                 sensorContextTester.fileSystem(),
@@ -103,10 +135,118 @@ class GosuSensorTest {
 
     private SensorContextTester createSensorContextTesterFor(String fileName, boolean isCancelled) {
         final SourceCodeFile sourceCodeFile = new GosuSourceCodeFile(fileName, TestResourcesDirectories.SENSOR_RESOURCES_DIR.getPathAsString());
+        return createSensorContextTesterFor(sourceCodeFile.asInputFile(), isCancelled);
+    }
+
+    private SensorContextTester createSensorContextTesterFor(InputFile inputFile, boolean isCancelled) {
         final GosuSensorContextTester sensorContextTester = new GosuSensorContextTester(TestResourcesDirectories.SENSOR_RESOURCES_DIR.getPath(), "MagicNumbersRule");
         final SensorContextTester sensorContext = sensorContextTester.get();
         sensorContext.setCancelled(isCancelled);
-        sensorContext.fileSystem().add(sourceCodeFile.asInputFile());
+        sensorContext.fileSystem().add(inputFile);
         return sensorContext;
+    }
+
+    private class ThrowingInputFile implements InputFile {
+
+        @Override
+        public String filename() {
+            return "throwing-input-file.gs";
+        }
+
+        @Override
+        public String relativePath() {
+            return null;
+        }
+
+        @Override
+        public String absolutePath() {
+            return null;
+        }
+
+        @Override
+        public File file() {
+            return null;
+        }
+
+        @Override
+        public Path path() {
+            return null;
+        }
+
+        @Override
+        public URI uri() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public String language() {
+            return GosuLanguage.KEY;
+        }
+
+        @Override
+        public Type type() {
+            return null;
+        }
+
+        @Override
+        public InputStream inputStream() throws IOException {
+            throw new IOException("Something exploded!!!");
+        }
+
+        @Override
+        public String contents() throws IOException {
+            return null;
+        }
+
+        @Override
+        public Status status() {
+            return null;
+        }
+
+        @Override
+        public int lines() {
+            return 0;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
+        }
+
+        @Override
+        public TextPointer newPointer(int line, int lineOffset) {
+            return new DefaultTextPointer(line, lineOffset);
+        }
+
+        @Override
+        public TextRange newRange(TextPointer start, TextPointer end) {
+            return null;
+        }
+
+        @Override
+        public TextRange newRange(int startLine, int startLineOffset, int endLine, int endLineOffset) {
+            return null;
+        }
+
+        @Override
+        public TextRange selectLine(int line) {
+            return null;
+        }
+
+        @Override
+        public Charset charset() {
+            return null;
+        }
+
+        @Override
+        public String key() {
+            return null;
+        }
+
+        @Override
+        public boolean isFile() {
+            return false;
+        }
     }
 }

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/tools/listeners/SyntaxErrorListenerTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/tools/listeners/SyntaxErrorListenerTest.java
@@ -42,8 +42,8 @@ class SyntaxErrorListenerTest {
         syntaxErrorListener.syntaxError(
                 aGosuLexer(),
                 "#",
-                1,
-                5,
+                19,
+                7,
                 "Syntax error",
                 new DummyRecognitionException()
         );
@@ -52,8 +52,8 @@ class SyntaxErrorListenerTest {
         assertThat(sensorContext.allAnalysisErrors()).hasSize(1).allSatisfy(analysisError -> {
             assertThat(analysisError.message()).isEqualTo("Syntax error");
             assertThat(analysisError.location()).isNotNull();
-            assertThat(analysisError.location().line()).isEqualTo(1);
-            assertThat(analysisError.location().lineOffset()).isEqualTo(5);
+            assertThat(analysisError.location().line()).isEqualTo(19);
+            assertThat(analysisError.location().lineOffset()).isEqualTo(7);
             assertThat(analysisError.inputFile()).isNotNull();
         });
 

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/utils/TextRangeUtilTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/utils/TextRangeUtilTest.java
@@ -36,6 +36,12 @@ class TextRangeUtilTest {
 
         assertThat(TextRangeUtil.fromPosition(0, 1, 0, 5)).isEqualTo(textRange);
         assertThat(TextRangeUtil.fromPointers(start, stop)).isEqualTo(textRange);
+        assertThat(TextRangeUtil.fromPointers(start, stop).start())
+                .isEqualByComparingTo(textRange.start())
+                .hasToString(textRange.start().toString());
+        assertThat(TextRangeUtil.fromPointers(start, stop).end())
+                .isEqualByComparingTo(textRange.end())
+                .hasToString(textRange.end().toString());
     }
 
     @Test
@@ -82,7 +88,6 @@ class TextRangeUtilTest {
         comment.setCharPositionInLine(11);
 
         TextRange textRangeFromTwoTokens = new DefaultTextRange(start, commentStop);
-
 
         assertThat(TextRangeUtil.fromToken(token)).isEqualTo(textRange);
         assertThat(TextRangeUtil.fromToken(comment)).isEqualTo(commentTextRange);

--- a/src/test/resources/listeners/syntax/GosuFile.gs
+++ b/src/test/resources/listeners/syntax/GosuFile.gs
@@ -16,7 +16,7 @@
  */
 package listeners.syntax
 
-class GosuFile {
+classs GosuFile {
   function doNothing() {
   }
 

--- a/src/testIntegration/java/de/friday/sonarqube/gosu/plugin/SimpleGosuProjectIT.java
+++ b/src/testIntegration/java/de/friday/sonarqube/gosu/plugin/SimpleGosuProjectIT.java
@@ -64,6 +64,12 @@ public class SimpleGosuProjectIT {
                             assertThat(issue.getScope()).isEqualTo("MAIN");
                             assertThat(issue.getSeverity()).isEqualTo(Common.Severity.INFO);
                             assertThat(issue.getMessage()).isEqualTo("Complete the task associated to this TODO comment.");
+                            assertThat(issue.getTextRange()).satisfies(textRange -> {
+                                assertThat(textRange.getStartLine()).isEqualTo(9);
+                                assertThat(textRange.getStartOffset()).isEqualTo(2);
+                                assertThat(textRange.getEndLine()).isEqualTo(9);
+                                assertThat(textRange.getEndOffset()).isEqualTo(15);
+                            });
                         }
                 );
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the pull request Title above -->

## Description
<!--- Describe your changes in detail -->
Remove direct usages of DefaultTextPointer, favoring it's interface instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since version 9.x, the internal implementations of some plugin interfaces were removed from the plugin base library and moved to the `sonar-plugin-api-impl` one. To be able to update the plugin to support v9.x we need to remove all direct usages of the default implementations. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [x] Tech Debt (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
