### PR TITLE
tech-debt: remove usages of DefaultTextRange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Removed direct usages of `DefaultTextPointer` [(#60)](https://github.com/FRI-DAY/sonar-gosu-plugin/pull/62).
+- Removed direct usages of `DefaultTextRange` [(#60)](https://github.com/FRI-DAY/sonar-gosu-plugin/pull/63).
+
 ## [1.2.0]
 
 ### Changed

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/utils/TextRangeUtil.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/utils/TextRangeUtil.java
@@ -27,7 +27,6 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.sonar.api.batch.fs.TextPointer;
 import org.sonar.api.batch.fs.TextRange;
-import org.sonar.api.batch.fs.internal.DefaultTextRange;
 
 public final class TextRangeUtil {
     private static final Pattern LINE_SEPARATOR = Pattern.compile("\\r?\\n");
@@ -50,7 +49,7 @@ public final class TextRangeUtil {
     }
 
     public static TextRange fromPointers(TextPointer start, TextPointer stop) {
-        return new DefaultTextRange(start, stop);
+        return new InternalTextRange(start, stop);
     }
 
     public static TextRange fromPosition(int startLine, int startOffset, int stopLine, int stopOffset) {
@@ -107,6 +106,51 @@ public final class TextRangeUtil {
             return token.getCharPositionInLine();
         } else {
             return token.getCharPositionInLine() + token.getText().length();
+        }
+    }
+
+    private static class InternalTextRange implements TextRange {
+
+        private final TextPointer start;
+        private final TextPointer end;
+
+        public InternalTextRange(TextPointer start, TextPointer end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        @Override
+        public TextPointer start() {
+            return start;
+        }
+
+        @Override
+        public TextPointer end() {
+            return end;
+        }
+
+        @Override
+        public boolean overlap(TextRange another) {
+            return this.end.compareTo(another.start()) > 0 && another.end().compareTo(this.start) > 0;
+        }
+
+        @Override
+        public String toString() {
+            return "Range[from " + start + " to " + end + "]";
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (!(obj instanceof TextRange)) {
+                return false;
+            }
+            final TextRange other = (TextRange) obj;
+            return this.start.equals(other.start()) && this.end.equals(other.end());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(this.start.hashCode(), this.end.hashCode());
         }
     }
 

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/utils/TextRangeUtilTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/utils/TextRangeUtilTest.java
@@ -34,8 +34,12 @@ class TextRangeUtilTest {
         TextPointer stop = new DefaultTextPointer(0, 5);
         TextRange textRange = new DefaultTextRange(start, stop);
 
-        assertThat(TextRangeUtil.fromPosition(0, 1, 0, 5)).isEqualTo(textRange);
-        assertThat(TextRangeUtil.fromPointers(start, stop)).isEqualTo(textRange);
+        assertThat(TextRangeUtil.fromPosition(0, 1, 0, 5))
+                .isEqualTo(textRange)
+                .hasToString(textRange.toString());
+        assertThat(TextRangeUtil.fromPointers(start, stop))
+                .isEqualTo(textRange)
+                .hasToString(textRange.toString());
         assertThat(TextRangeUtil.fromPointers(start, stop).start())
                 .isEqualByComparingTo(textRange.start())
                 .hasToString(textRange.start().toString());
@@ -64,9 +68,16 @@ class TextRangeUtilTest {
         parserRuleContext.start = token;
         parserRuleContext.stop = token;
 
-        assertThat(TextRangeUtil.fromToken(token)).isEqualTo(textRange);
-        assertThat(TextRangeUtil.fromContext(parserRuleContext)).isEqualTo(textRange);
-        assertThat(TextRangeUtil.fromTokens(token, token2)).isEqualTo(textRange2);
+        assertThat(TextRangeUtil.fromToken(token))
+                .isEqualTo(textRange)
+                .hasToString(textRange.toString())
+                .isNotEqualTo(textRange2);
+        assertThat(TextRangeUtil.fromContext(parserRuleContext))
+                .isEqualTo(textRange)
+                .hasToString(textRange.toString());
+        assertThat(TextRangeUtil.fromTokens(token, token2))
+                .isEqualTo(textRange2)
+                .hasToString(textRange2.toString());
     }
 
     @Test


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the pull request Title above -->

## Description
<!--- Describe your changes in detail -->
Remove direct usages of DefaultTextRange, favoring its interface instead.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since version 9.x, the internal implementations of some plugin interfaces were removed from the plugin base library and moved to the `sonar-plugin-api-impl` one. To be able to update the plugin to support v9.x we need to remove all direct usages of the default implementations. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [x] Tech Debt (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
