### PR TITLE
tech-debt: remove usage of ProfileDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Removed direct usages of `DefaultTextPointer` [(#60)](https://github.com/FRI-DAY/sonar-gosu-plugin/pull/62).
-- Removed direct usages of `DefaultTextRange` [(#60)](https://github.com/FRI-DAY/sonar-gosu-plugin/pull/63).
+- Removed direct usages of `DefaultTextPointer` [(#62)](https://github.com/FRI-DAY/sonar-gosu-plugin/pull/62).
+- Removed direct usages of `DefaultTextRange` [(#63)](https://github.com/FRI-DAY/sonar-gosu-plugin/pull/63).
+- Replace usage of `ProfileDefinition` by `QualityProfilesServiceAdapter` [(#64)](https://github.com/FRI-DAY/sonar-gosu-plugin/pull/64).
 
 ## [1.2.0]
 

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/GosuRulesDefinition.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/GosuRulesDefinition.java
@@ -24,6 +24,9 @@ import org.sonar.api.server.rule.RulesDefinition;
 import org.sonarsource.analyzer.commons.RuleMetadataLoader;
 
 public class GosuRulesDefinition implements RulesDefinition {
+
+    public static final String COMMON_REPOSITORY_KEY = "common-gosu";
+
     private final SonarRuntime sonarRuntime;
 
     public GosuRulesDefinition(SonarRuntime sonarRuntime) {

--- a/src/testIntegration/java/de/friday/sonarqube/gosu/plugin/PluginInstallationIT.java
+++ b/src/testIntegration/java/de/friday/sonarqube/gosu/plugin/PluginInstallationIT.java
@@ -19,8 +19,10 @@ package de.friday.sonarqube.gosu.plugin;
 import de.friday.test.config.IntegrationTest;
 import de.friday.test.framework.sonar.server.SonarServer;
 import de.friday.test.framework.sonar.ws.client.SonarWebServicesClient;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonarqube.ws.Plugins;
+import org.sonarqube.ws.Qualityprofiles;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IntegrationTest
@@ -45,6 +47,24 @@ public class PluginInstallationIT {
                     assertThat(pluginDetails.getDescription()).isEqualTo("Gosu Programming Language Plugin for SonarQube");
                     assertThat(pluginDetails.getLicense()).isEqualTo("GNU AGPL 3");
                     assertThat(pluginDetails.getOrganizationName()).isEqualTo("FRIDAY Insurance S.A.");
+                }
+        );
+    }
+
+    @Test
+    void shouldCreateDefaultProfileWithAllRules() {
+        //when
+        final List<Qualityprofiles.SearchWsResponse.QualityProfile> qualityProfiles = sonarClient.qualityProfiles().findAllProfilesOf("gosu");
+
+        //then
+        assertThat(qualityProfiles).hasSize(1).allSatisfy(
+                qualityProfile -> {
+                    assertThat(qualityProfile.getName()).isEqualTo("Sonar way");
+                    assertThat(qualityProfile.getLanguage()).isEqualTo("gosu");
+                    assertThat(qualityProfile.getLanguageName()).isEqualTo("Gosu");
+                    assertThat(qualityProfile.getActiveRuleCount()).isEqualTo(28);
+                    assertThat(qualityProfile.getIsDefault()).isTrue();
+                    assertThat(qualityProfile.getIsBuiltIn()).isTrue();
                 }
         );
     }

--- a/src/testIntegration/java/de/friday/test/framework/sonar/ws/client/QualityProfilesServiceAdapter.java
+++ b/src/testIntegration/java/de/friday/test/framework/sonar/ws/client/QualityProfilesServiceAdapter.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.test.framework.sonar.ws.client;
+
+import java.util.List;
+import org.sonarqube.ws.Qualityprofiles;
+import org.sonarqube.ws.client.HttpConnector;
+import org.sonarqube.ws.client.qualityprofiles.QualityprofilesService;
+import org.sonarqube.ws.client.qualityprofiles.SearchRequest;
+
+public class QualityProfilesServiceAdapter extends QualityprofilesService {
+    public QualityProfilesServiceAdapter(HttpConnector connector) {
+        super(connector);
+    }
+
+    public List<Qualityprofiles.SearchWsResponse.QualityProfile> findAllProfilesOf(String language) {
+        return this.search(new SearchRequest().setLanguage(language)).getProfilesList();
+    }
+
+}

--- a/src/testIntegration/java/de/friday/test/framework/sonar/ws/client/SonarWebServicesClient.java
+++ b/src/testIntegration/java/de/friday/test/framework/sonar/ws/client/SonarWebServicesClient.java
@@ -17,9 +17,7 @@
 package de.friday.test.framework.sonar.ws.client;
 
 import org.sonarqube.ws.client.HttpConnector;
-import org.sonarqube.ws.client.issues.IssuesService;
 import org.sonarqube.ws.client.projects.ProjectsService;
-import org.sonarqube.ws.client.qualityprofiles.QualityprofilesService;
 
 public class SonarWebServicesClient {
 
@@ -46,7 +44,7 @@ public class SonarWebServicesClient {
         return new ProjectsService(connector);
     }
 
-    public QualityprofilesService qualityProfiles() {
-        return new QualityprofilesService(connector);
+    public QualityProfilesServiceAdapter qualityProfiles() {
+        return new QualityProfilesServiceAdapter(connector);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the pull request Title above -->

## Description
<!--- Describe your changes in detail -->
Replace the usage of `ProfileDefinition`, which has been deprecated, with `BuiltInQualityProfilesDefinition`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Since version 9.x, ProfileDefinition has been removed from the runtime plugin implementation. In order to make the plugin compatible with version 9+, it's required to usage the `BuiltInQualityProfilesDefinition` interface.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [x] Tech Debt (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
