### PR TITLE
feat: remove deprecated DuplicatedBlocks rule

### DIFF
--- a/src/main/java/de/friday/sonarqube/gosu/plugin/GosuQualityProfile.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/GosuQualityProfile.java
@@ -38,12 +38,6 @@ public class GosuQualityProfile implements BuiltInQualityProfilesDefinition {
 
     public void activateRules(NewBuiltInQualityProfile builtInQualityProfile) {
         RulesKeysExtractor.getAllRulesKeys().forEach(ruleKey -> activateRule(ruleKey, builtInQualityProfile));
-        activateDefaultRules(builtInQualityProfile);
-    }
-
-    private void activateDefaultRules(NewBuiltInQualityProfile builtInQualityProfile) {
-        final Rule duplicatedBlocks = Rule.create(GosuRulesDefinition.COMMON_REPOSITORY_KEY, "DuplicatedBlocks");
-        builtInQualityProfile.activateRule(duplicatedBlocks.getRepositoryKey(), duplicatedBlocks.getKey());
     }
 
     private void activateRule(String ruleKey, NewBuiltInQualityProfile builtInQualityProfile) {

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/GosuQualityProfileTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/GosuQualityProfileTest.java
@@ -44,7 +44,7 @@ class GosuQualityProfileTest {
                 .hasSize(expectedNumberOfActiveGosuRules());
         assertThat(rulesProfile.rules())
                 .filteredOn(activeRule -> activeRule.repoKey().equals(GosuRulesDefinition.COMMON_REPOSITORY_KEY))
-                .hasSize(1);
+                .isEmpty();
     }
 
     private int expectedNumberOfActiveGosuRules() {

--- a/src/testIntegration/java/de/friday/sonarqube/gosu/plugin/PluginInstallationIT.java
+++ b/src/testIntegration/java/de/friday/sonarqube/gosu/plugin/PluginInstallationIT.java
@@ -62,7 +62,7 @@ public class PluginInstallationIT {
                     assertThat(qualityProfile.getName()).isEqualTo("Sonar way");
                     assertThat(qualityProfile.getLanguage()).isEqualTo("gosu");
                     assertThat(qualityProfile.getLanguageName()).isEqualTo("Gosu");
-                    assertThat(qualityProfile.getActiveRuleCount()).isEqualTo(28);
+                    assertThat(qualityProfile.getActiveRuleCount()).isEqualTo(27);
                     assertThat(qualityProfile.getIsDefault()).isTrue();
                     assertThat(qualityProfile.getIsBuiltIn()).isTrue();
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the pull request Title above -->

## Description
<!--- Describe your changes in detail -->
Removes the usage of the common DuplicatedBlocks rule from the built-in profile. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The rule was deprecated some time ago and was removed on Sonarqube v10+. 
![deprecated-rule](https://user-images.githubusercontent.com/4359233/233572321-194a2539-10b6-4ca2-ac5a-3eb6d40a7dd1.png)

## Screenshots (if appropriate):
No deprecated rule in the built-in profile anymore:
![quality-profile](https://user-images.githubusercontent.com/4359233/233572986-de85e275-2219-4cd1-9597-2ba19b3556f5.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [x] Tech Debt (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
