### PR TITLE
bug-fix: UnnecessaryImportRule highlights unused import on its line

### DIFF
--- a/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
@@ -52,7 +52,6 @@ public class UnnecessaryImportRule extends BaseGosuRule {
 
     private String currentPackage;
     private boolean afterUsesStatements = false;
-    private GosuParser.UsesStatementListContext usesStatementContext;
 
     @Override
     protected String getKey() {
@@ -89,7 +88,6 @@ public class UnnecessaryImportRule extends BaseGosuRule {
 
     @Override
     public void exitUsesStatementList(GosuParser.UsesStatementListContext ctx) {
-        usesStatementContext = ctx;
         afterUsesStatements = true;
     }
 
@@ -107,7 +105,7 @@ public class UnnecessaryImportRule extends BaseGosuRule {
         allImports.stream()
                 .filter(this::isUnusedImport)
                 .forEach(unusedImport ->
-                        addIssueWithMessage("There is unused import of " + unusedImport.getValue() + ".", usesStatementContext)
+                        addIssueWithMessage("There is unused import of " + unusedImport.getValue() + ".", unusedImport.getContext())
                 );
     }
 

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
@@ -16,9 +16,14 @@
  */
 package de.friday.sonarqube.gosu.plugin.rules.smells;
 
+import de.friday.test.support.rules.dsl.gosu.GosuIssueLocations;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static de.friday.test.support.rules.dsl.gosu.GosuRuleTestDsl.given;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UnnecessaryImportRuleTest {
 
@@ -49,5 +54,19 @@ class UnnecessaryImportRuleTest {
         given("UnnecessaryImportRule/nokWithInnerClass.gs")
                 .whenCheckedAgainst(UnnecessaryImportRule.class)
                 .then().issuesFound().hasSizeEqualTo(1);
+    }
+
+    @Test
+    void findsIssuesWhenUnnecessaryImportIsFoundOnClassAndVerifyUnderlying() {
+        given("UnnecessaryImportRule/nokUnusedImport.gs")
+                .whenCheckedAgainst(UnnecessaryImportRule.class)
+                .then().issuesFound()
+                .hasSizeEqualTo(2)
+                .areLocatedOn(
+                        GosuIssueLocations.of(
+                                Arrays.asList(3, 6, 3, 26),
+                                Arrays.asList(6, 6, 6, 25)
+                        )
+                );
     }
 }

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
@@ -22,8 +22,6 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 
 import static de.friday.test.support.rules.dsl.gosu.GosuRuleTestDsl.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UnnecessaryImportRuleTest {
 
@@ -38,7 +36,26 @@ class UnnecessaryImportRuleTest {
     void findsIssuesWhenUnnecessaryImportIsFound() {
         given("UnnecessaryImportRule/nok.gs")
                 .whenCheckedAgainst(UnnecessaryImportRule.class)
-                .then().issuesFound().hasSizeEqualTo(7);
+                .then()
+                .issuesFound()
+                .hasSizeEqualTo(7)
+                .areLocatedOn(
+                        GosuIssueLocations.of(
+                                // java.lang
+                                Arrays.asList(4, 6, 4, 22),
+                                // gw typekey
+                                Arrays.asList(5, 6, 5, 27),
+                                // gw entity
+                                Arrays.asList(6, 6, 6, 18),
+                                Arrays.asList(7, 6, 7, 32),
+                                // same package used
+                                Arrays.asList(8, 6, 8, 23),
+                                // duplicated imports
+                                Arrays.asList(11, 6, 11, 37),
+                                // unused imports
+                                Arrays.asList(9, 6, 9, 32)
+                        )
+                );
     }
 
     @Test
@@ -64,8 +81,8 @@ class UnnecessaryImportRuleTest {
                 .hasSizeEqualTo(2)
                 .areLocatedOn(
                         GosuIssueLocations.of(
-                                Arrays.asList(3, 6, 3, 26),
-                                Arrays.asList(6, 6, 6, 25)
+                                Arrays.asList(6, 6, 6, 25),
+                                Arrays.asList(3, 6, 3, 26)
                         )
                 );
     }

--- a/src/test/resources/rules/UnnecessaryImportRule/nokUnusedImport.gs
+++ b/src/test/resources/rules/UnnecessaryImportRule/nokUnusedImport.gs
@@ -1,0 +1,20 @@
+package friday.lob.fho
+
+uses java.time.ZoneOffset
+uses java.time.LocalDate
+uses java.time.LocalDateTime
+uses java.time.LocalTime
+
+class SampleClassUnusedImports {
+  function createLocalDate(): LocalDate {
+    return null
+  }
+
+  function createLocalDateTime(): LocalDateTime {
+    return null
+  }
+
+  function createDate(): Date {
+    return null
+  }
+}


### PR DESCRIPTION
## Description
More details in the issue [(#86) UnnecessaryImportRule - underline only the line with unused import](https://github.com/FRI-DAY/sonar-gosu-plugin/issues/86)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [ ] Tech Debt (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
