### PR TITLE
feat: enable UnnecessaryImportRule to exclude specific import namespace from analysis

### DIFF
--- a/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
@@ -20,6 +20,11 @@ import de.friday.sonarqube.gosu.antlr.GosuParser;
 import de.friday.sonarqube.gosu.language.statements.UsesStatement;
 import de.friday.sonarqube.gosu.plugin.issues.GosuIssue;
 import de.friday.sonarqube.gosu.plugin.rules.BaseGosuRule;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.tree.ParseTree;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -27,17 +32,24 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import org.antlr.v4.runtime.ParserRuleContext;
-import org.antlr.v4.runtime.tree.ParseTree;
-import org.sonar.check.Rule;
+import java.util.stream.Stream;
 
 @Rule(key = UnnecessaryImportRule.KEY)
 public class UnnecessaryImportRule extends BaseGosuRule {
 
     static final String KEY = "UnnecessaryImportRule";
 
+    private static final String DEFAULT_EXPLICIT_NAMESPACES = "";
+
     private final Set<UsesStatement> allImports = new HashSet<>();
     private final Set<String> allReferencedClasses = new HashSet<>();
+    @RuleProperty(
+            key = "AllowedExplicitImportNamespaces",
+            description = "Comma-separated list of explicit import namespaces allowed.",
+            defaultValue = DEFAULT_EXPLICIT_NAMESPACES
+    )
+    private String defaultExplicitNamespaces = DEFAULT_EXPLICIT_NAMESPACES;
+
     private String currentPackage;
     private boolean afterUsesStatements = false;
     private GosuParser.UsesStatementListContext usesStatementContext;
@@ -112,17 +124,24 @@ public class UnnecessaryImportRule extends BaseGosuRule {
         return !usesStatement.isWildcardImport();
     }
 
+    private Stream<String> explicitNamespaces() {
+        return Arrays.stream(
+                        defaultExplicitNamespaces.split(","))
+                .filter(s -> !s.isEmpty());
+    }
+
     private void checkUnnecessaryImports(UsesStatement usesStatement) {
         checkSamePackageImport(usesStatement);
         checkDuplicateImport(usesStatement);
 
+
         AlwaysAvailableTypes.forEach(
-                alwaysAvailableType -> checkUsageOfClassesAlwaysAvailable(alwaysAvailableType, usesStatement)
-        );
+                alwaysAvailableType -> checkUsageOfClassesAlwaysAvailable(alwaysAvailableType, usesStatement));
     }
 
     private void checkUsageOfClassesAlwaysAvailable(AlwaysAvailableTypes alwaysAvailableType, UsesStatement usesStatement) {
-        if (usesStatement.startsWith(alwaysAvailableType.packagePrefix)) {
+        if (usesStatement.startsWith(alwaysAvailableType.packagePrefix)
+                && explicitNamespaces().noneMatch(usesStatement::startsWith)) {
             addIssueWithMessage(
                     "Unnecessary import, " + alwaysAvailableType.description + " are always available.",
                     usesStatement.getContext()

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
@@ -17,6 +17,7 @@
 package de.friday.sonarqube.gosu.plugin.rules.smells;
 
 import org.junit.jupiter.api.Test;
+
 import static de.friday.test.support.rules.dsl.gosu.GosuRuleTestDsl.given;
 
 class UnnecessaryImportRuleTest {
@@ -32,6 +33,14 @@ class UnnecessaryImportRuleTest {
     void findsIssuesWhenUnnecessaryImportIsFound() {
         given("UnnecessaryImportRule/nok.gs")
                 .whenCheckedAgainst(UnnecessaryImportRule.class)
+                .then().issuesFound().hasSizeEqualTo(7);
+    }
+
+    @Test
+    void findsIssuesWhenUnnecessaryImportIsFoundAndAllowedExplicitImportNamespacesIsCustom() {
+        given("UnnecessaryImportRule/nok.gs")
+                .whenCheckedAgainst(UnnecessaryImportRule.class)
+                .withRuleProperty("AllowedExplicitImportNamespaces", "entity.windowed.")
                 .then().issuesFound().hasSizeEqualTo(6);
     }
 

--- a/src/test/resources/rules/UnnecessaryImportRule/nok.gs
+++ b/src/test/resources/rules/UnnecessaryImportRule/nok.gs
@@ -4,6 +4,7 @@ uses friday.cc.gdv.GdvInvoiceWrapper
 uses java.lang.Object
 uses typekey.SalvageStatus
 uses entity.Claim
+uses entity.windowed.ClaimOwner
 uses checks.OtherClass
 uses checks.nested.UnusedImport
 uses checks.nested.SomethingElse
@@ -20,6 +21,7 @@ class nok {
     final var claim = new Claim() {
       :SalvageStatus = SalvageStatus.FakeStatus,
       :Object = object
+      :ClaimOwner = new ClaimOwner()
     }
 
     return claim


### PR DESCRIPTION
## Description
More details in the issue [(#85) UnnecessaryImportRule - skip imports for auto-generated entitties](https://github.com/FRI-DAY/sonar-gosu-plugin/issues/85)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [ ] Tech Debt (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.