### PR TITLE
tech-debit: enable SonarCloud analysis on PRs from forks repositories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+name: Build
+
 on:
   pull_request:
     paths-ignore:
@@ -15,19 +17,23 @@ jobs:
             SONAR_PLUGIN_API_VERSION: 6.7.7
             SONAR_JAVA_VERSION: 7.11.0.29148
             SONAR_SERVER_JAVA_VERSION: 11
+            UPLOAD_ARTIFACTS: false
           - SONAR_SERVER_VERSION: 9.7.0.61563
             SONAR_PLUGIN_API_VERSION: 6.7.7
             SONAR_JAVA_VERSION: 7.13.0.29990
             SONAR_SERVER_JAVA_VERSION: 11
+            UPLOAD_ARTIFACTS: true
           # current LTS version
           - SONAR_SERVER_VERSION: 9.9.0.65466
             SONAR_PLUGIN_API_VERSION: 6.7.7
             SONAR_JAVA_VERSION: 7.13.0.29990
             SONAR_SERVER_JAVA_VERSION: 17
+            UPLOAD_ARTIFACTS: false
           - SONAR_SERVER_VERSION: 10.0.0.68432
             SONAR_PLUGIN_API_VERSION: 6.7.7
             SONAR_JAVA_VERSION: 7.13.0.29990
             SONAR_SERVER_JAVA_VERSION: 17
+            UPLOAD_ARTIFACTS: false
     steps:
       - uses: actions/checkout@v3
         with:
@@ -38,12 +44,6 @@ jobs:
           java-version: ${{ matrix.SONAR_SERVER_JAVA_VERSION }}
           distribution: temurin
           cache: 'gradle'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
       - name: Cache Gradle packages
         uses: actions/cache@v3
         with:
@@ -55,19 +55,12 @@ jobs:
                     ${{ runner.os }}-gradle-
       - name: Build
         run: |
-          ./gradlew build sonar --build-cache --no-daemon \
+          ./gradlew build --build-cache --no-daemon \
             -PsonarPluginApiVersion=${{ matrix.SONAR_PLUGIN_API_VERSION }} \
-            -PsonarJavaVersion=${{ matrix.SONAR_JAVA_VERSION }} \
-            -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }} \
-            -Dsonar.organization=${{ env.SONAR_ORGANIZATION }} \
-            -Dsonar.host.url=${{ env.SONAR_HOST_URL }} \
-            -Dsonar.pullrequest.provider=github \
-            -Dsonar.pullrequest.github.repository=${{ github.repository }} \
-            -Dsonar.pullrequest.key=${{ github.event.number }} \
-            -Dsonar.pullrequest.base=${{ github.base_ref }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
-          SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
-          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+            -PsonarJavaVersion=${{ matrix.SONAR_JAVA_VERSION }}
+      - name: Upload Build Artifacts
+        if: success() && matrix.UPLOAD_ARTIFACTS == true
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-artifacts
+          path: build/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+name: Release
+
 on:
   push:
     branches:

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,85 @@
+name: SonarCloud
+
+# We run the SonarCloud on a specific workflow, triggered by the Build workflow completion,
+# to be able to safely use sensitive configuration (aka secrets) on the PRs triggered from fork repositories.
+# Ref.:
+# - https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+# - https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/30
+
+on:
+  workflow_run:
+    workflows: [Build]
+    types: [completed]
+
+jobs:
+  sonar:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: 11
+          distribution: temurin
+          cache: 'gradle'
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Download Build Artifacts
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "build-artifacts"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/build-artifacts.zip`, Buffer.from(download.data));
+      - name: Unzip Build Artifacts
+        run: unzip build-artifacts.zip -d build
+      - name: Run SonarCloud Scan
+        run: |
+          ./gradlew sonar --build-cache --no-daemon \
+            -Dsonar.projectKey=${{ env.SONAR_PROJECT_KEY }}
+            -Dsonar.organization=${{ env.SONAR_ORGANIZATION }}
+            -Dsonar.host.url=${{ env.SONAR_HOST_URL }}
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.provider=github
+            -Dsonar.pullrequest.github.repository=${{ github.repository }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
+          SONAR_ORGANIZATION: ${{ secrets.SONAR_ORGANIZATION }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the pull request Title above -->

## Description
<!--- Describe your changes in detail -->
By design, Github workflows triggered by fork repositories don't have access to secret configurations. This is due to the risk of third-party actors pushing malicious code on PRs to exploit secret data. 
This causes the SonarCloud analysis to [fail](https://github.com/FRI-DAY/sonar-gosu-plugin/pull/88/checks) on PRs from fork repositories due to the Sonar variables not being available on the workflow. 

To be able to run the SonarCloud analysis safely on PRs from fork repositories we need to split the process and run the SonarCloud analysis on its own workflow that is triggered at the end of the build process. This workflow will have proper access to the configuration needed to successfully run the SonarCloud analysis. 

-------------
Ref.:
- [Keeping your GitHub Actions and workflows secure](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)
- [How to use SonarCloud with a forked repository on GitHub?](https://community.sonarsource.com/t/how-to-use-sonarcloud-with-a-forked-repository-on-github/7363/30)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Be able to run SonarCloud safely on PRs from fork repositories as well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [x] Tech Debt (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
