### PR TITLE
bug-fix: UnnecessaryImportRule avoids trying to map class names of wildcard imports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation "org.sonarsource.sonarqube:sonar-ws:${sonarqubeWsVersion}"
     testImplementation 'com.google.protobuf:protobuf-java-util:3.23.3'
     testImplementation 'org.sonarsource.orchestrator:sonar-orchestrator-junit5:4.0.0.404'
+    testImplementation 'org.mockito:mockito-core:3.+'
     testRuntimeOnly "org.sonarsource.sonarqube:sonar-plugin-api:${sonarPluginApiVersion}"
     testRuntimeOnly 'ch.qos.logback:logback-classic:1.4.8'
 }

--- a/src/main/java/de/friday/sonarqube/gosu/language/statements/UsesStatement.java
+++ b/src/main/java/de/friday/sonarqube/gosu/language/statements/UsesStatement.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.sonarqube.gosu.language.statements;
+
+import de.friday.sonarqube.gosu.antlr.GosuParser;
+import java.util.Objects;
+import org.antlr.v4.runtime.Token;
+
+public final class UsesStatement {
+    private final String uses;
+    private final Token stopToken;
+    private final GosuParser.UsesStatementContext context;
+
+    public UsesStatement(GosuParser.UsesStatementContext context) {
+        this.uses = context.namespace().getText();
+        this.stopToken = context.getStop();
+        this.context = context;
+    }
+
+    public String getValue() {
+        return uses;
+    }
+
+    public GosuParser.UsesStatementContext getContext() {
+        return context;
+    }
+
+    public boolean isWildcardImport() {
+        return stopToken.getType() == GosuParser.MUL;
+    }
+
+    public String getClassName() {
+        final int lastIndexOfDot = uses.lastIndexOf('.');
+        if (lastIndexOfDot == -1) {
+            throw new ClassNameUnavailableException(uses);
+        }
+
+        return uses.substring(lastIndexOfDot + 1);
+    }
+
+    public boolean startsWith(String prefix) {
+        return uses.startsWith(prefix);
+    }
+
+    public boolean hasSamePackageAs(String aPackageStatement) {
+        return uses.equals(aPackageStatement) || packagesAreEqual(aPackageStatement);
+    }
+
+    private boolean packagesAreEqual(String aPackageStatement) {
+        return uses.startsWith(aPackageStatement)
+                && uses.charAt(aPackageStatement.length()) == '.'
+                && uses.indexOf('.', aPackageStatement.length() + 1) == -1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UsesStatement that = (UsesStatement) o;
+        return Objects.equals(uses, that.uses);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uses);
+    }
+
+    private final class ClassNameUnavailableException extends IllegalArgumentException {
+        ClassNameUnavailableException(String usesStatement) {
+            super("Could not determine the class name of the uses statement: " + usesStatement);
+        }
+    }
+}

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
@@ -93,13 +93,23 @@ public class UnnecessaryImportRule extends BaseGosuRule {
     @Override
     public void exitStart(GosuParser.StartContext ctx) {
         allImports.stream()
-                .filter((usesStatement) -> !allReferencedClasses.contains(usesStatement.getClassName()))
+                .filter(this::isUnusedImport)
                 .forEach(unusedImport ->
-                        addIssueWithMessage(
-                                "There is unused import of " + unusedImport.getValue() + ".",
-                                usesStatementContext
-                        )
+                        addIssueWithMessage("There is unused import of " + unusedImport.getValue() + ".", usesStatementContext)
                 );
+    }
+
+    private boolean isUnusedImport(UsesStatement usesStatement) {
+        return isNotWildcardImport(usesStatement)
+                && isUnreferencedClass(usesStatement);
+    }
+
+    private boolean isUnreferencedClass(UsesStatement usesStatement) {
+        return !allReferencedClasses.contains(usesStatement.getClassName());
+    }
+
+    private boolean isNotWildcardImport(UsesStatement usesStatement) {
+        return !usesStatement.isWildcardImport();
     }
 
     private void checkUnnecessaryImports(UsesStatement usesStatement) {

--- a/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
+++ b/src/main/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRule.java
@@ -17,12 +17,15 @@
 package de.friday.sonarqube.gosu.plugin.rules.smells;
 
 import de.friday.sonarqube.gosu.antlr.GosuParser;
-import de.friday.sonarqube.gosu.plugin.rules.BaseGosuRule;
+import de.friday.sonarqube.gosu.language.statements.UsesStatement;
 import de.friday.sonarqube.gosu.plugin.issues.GosuIssue;
+import de.friday.sonarqube.gosu.plugin.rules.BaseGosuRule;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -33,7 +36,7 @@ public class UnnecessaryImportRule extends BaseGosuRule {
 
     static final String KEY = "UnnecessaryImportRule";
 
-    private final Set<String> allImports = new HashSet<>();
+    private final Set<UsesStatement> allImports = new HashSet<>();
     private final Set<String> allReferencedClasses = new HashSet<>();
     private String currentPackage;
     private boolean afterUsesStatements = false;
@@ -52,8 +55,8 @@ public class UnnecessaryImportRule extends BaseGosuRule {
     @Override
     public void exitUsesStatement(GosuParser.UsesStatementContext context) {
         if (isNamespaceAvailable(context)) {
-            final String usesStatement = context.namespace().getText();
-            checkUnnecessaryImport(usesStatement, context);
+            final UsesStatement usesStatement = new UsesStatement(context);
+            checkUnnecessaryImports(usesStatement);
             allImports.add(usesStatement);
         }
     }
@@ -89,49 +92,58 @@ public class UnnecessaryImportRule extends BaseGosuRule {
 
     @Override
     public void exitStart(GosuParser.StartContext ctx) {
-        final Set<String> allImportedClasses = allImports.stream()
-                .map(this::getClassName)
-                .collect(Collectors.toSet());
-
-        allImportedClasses.removeAll(allReferencedClasses);
-        allImportedClasses.forEach(unusedImport ->
-                addIssueWithMessage("There is unused import of " + unusedImport + ".", usesStatementContext)
-        );
+        allImports.stream()
+                .filter((usesStatement) -> !allReferencedClasses.contains(usesStatement.getClassName()))
+                .forEach(unusedImport ->
+                        addIssueWithMessage(
+                                "There is unused import of " + unusedImport.getValue() + ".",
+                                usesStatementContext
+                        )
+                );
     }
 
-    private void checkUnnecessaryImport(String usesStatement, GosuParser.UsesStatementContext ctx) {
-        checkJavaLangImport(usesStatement, ctx);
-        checkGwPersistedObjectsImport(usesStatement, ctx);
-        checkSamePackageImport(usesStatement, ctx);
-        checkDuplicateImport(usesStatement, ctx);
+    private void checkUnnecessaryImports(UsesStatement usesStatement) {
+        checkJavaLangImport(usesStatement);
+        checkGwPersistedObjectsImport(usesStatement);
+        checkSamePackageImport(usesStatement);
+        checkDuplicateImport(usesStatement);
     }
 
-    private void checkJavaLangImport(String usesStatement, GosuParser.UsesStatementContext ctx) {
+    private void checkJavaLangImport(UsesStatement usesStatement) {
         if (usesStatement.startsWith("java.lang.")) {
-            addIssueWithMessage("Unnecessary import, java.lang classes are always available.", ctx);
+            addIssueWithMessage(
+                    "Unnecessary import, java.lang classes are always available.",
+                    usesStatement.getContext()
+            );
         }
     }
 
-    private void checkGwPersistedObjectsImport(String usesStatement, GosuParser.UsesStatementContext ctx) {
+    private void checkGwPersistedObjectsImport(UsesStatement usesStatement) {
         if (usesStatement.startsWith("typekey.") || usesStatement.startsWith("entity.")) {
-            addIssueWithMessage("Unnecessary import, typekey and entity classes are always available.", ctx);
+            addIssueWithMessage(
+                    "Unnecessary import, typekey and entity classes are always available.",
+                    usesStatement.getContext()
+            );
         }
     }
 
-    private void checkSamePackageImport(String usesStatement, GosuParser.UsesStatementContext ctx) {
+    private void checkSamePackageImport(UsesStatement usesStatement) {
         Objects.requireNonNull(currentPackage);
 
-        if (usesStatement.equals(currentPackage)
-                || (usesStatement.startsWith(currentPackage)
-                && usesStatement.charAt(currentPackage.length()) == '.'
-                && usesStatement.indexOf('.', currentPackage.length() + 1) == -1)) {
-            addIssueWithMessage("Unnecessary import, same package classes are always available.", ctx);
+        if (usesStatement.hasSamePackageAs(currentPackage)) {
+            addIssueWithMessage(
+                    "Unnecessary import, same package classes are always available.",
+                    usesStatement.getContext()
+            );
         }
     }
 
-    private void checkDuplicateImport(String usesStatement, GosuParser.UsesStatementContext ctx) {
+    private void checkDuplicateImport(UsesStatement usesStatement) {
         if (allImports.contains(usesStatement)) {
-            addIssueWithMessage("Unnecessary import, it is a duplicate.", ctx);
+            addIssueWithMessage(
+                    "Unnecessary import, it is a duplicate.",
+                    usesStatement.getContext()
+            );
         }
     }
 
@@ -142,14 +154,4 @@ public class UnnecessaryImportRule extends BaseGosuRule {
                 .build()
         );
     }
-
-    String getClassName(String usesStatement) {
-        int lastIndexOfDot = usesStatement.lastIndexOf('.');
-        if (lastIndexOfDot == -1) {
-            throw new IllegalArgumentException("No package found.");
-        }
-
-        return usesStatement.substring(lastIndexOfDot + 1);
-    }
-
 }

--- a/src/test/java/de/friday/sonarqube/gosu/language/statements/UsesStatementTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/language/statements/UsesStatementTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2023 FRIDAY Insurance S.A.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+package de.friday.sonarqube.gosu.language.statements;
+
+import de.friday.sonarqube.gosu.antlr.GosuLexer;
+import de.friday.sonarqube.gosu.antlr.GosuParser;
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.Token;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UsesStatementTest {
+
+    @Test
+    void shouldReturnTrueWhenIsWildcardImport() {
+        // given
+        final UsesStatement aUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "de.friday.SomeClass", aWildcardToken()
+        ));
+
+        // when
+        final boolean isWildCardImport = aUsesStatement.isWildcardImport();
+
+        // then
+        assertThat(isWildCardImport).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenIsNotWildcardImport() {
+        // given
+        final UsesStatement aUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "de.friday.SomeClass", aIdentifierTokenFor("SomeClass")
+        ));
+
+        // when
+        final boolean isWildCardImport = aUsesStatement.isWildcardImport();
+
+        // then
+        assertThat(isWildCardImport).isFalse();
+    }
+
+    @Test
+    void shouldReturnUsesClassName() {
+        // given
+        final UsesStatement aUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "de.friday.MyClass", aIdentifierTokenFor("MyClass")
+        ));
+
+        // when
+        final String className = aUsesStatement.getClassName();
+
+        // then
+        assertThat(className).isEqualTo("MyClass");
+    }
+
+    @Test
+    void shouldThrowClassNameUnavailableExceptionWhenClassNameCanNotBeDetermined() {
+        // given
+        final UsesStatement aUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "somePackage", aWildcardToken()
+        ));
+
+        // when // then
+        assertThatThrownBy(aUsesStatement::getClassName)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Could not determine the class name of the uses statement: somePackage");
+    }
+
+    @Test
+    void shouldReturnTrueWhenObjectsAreIdentical() {
+        // given
+        final UsesStatement aUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "de.friday.MyClass", aIdentifierTokenFor("MyClass")
+        ));
+        final UsesStatement anotherUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "de.friday.MyClass", aIdentifierTokenFor("MyClass")
+        ));
+
+        // when // then
+        assertThat(aUsesStatement).isEqualTo(anotherUsesStatement);
+    }
+
+    @Test
+    void shouldReturnFalseWhenObjectsAreDifferent() {
+        // given
+        final UsesStatement aUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "de.friday.MyClass", aIdentifierTokenFor("MyClass")
+        ));
+        final UsesStatement anotherUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "java.HelloWorld", aIdentifierTokenFor("HelloWorld")
+        ));
+
+        // when // then
+        assertThat(aUsesStatement).isNotEqualTo(anotherUsesStatement);
+    }
+
+    @Test
+    void shouldReturnTrueWhenUsesStatementsHaveSamePackages() {
+        // given
+        final String aPackage = "de.friday.api";
+        final UsesStatement aUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "de.friday.api.PotatoesApi", aIdentifierTokenFor("PotatoesAPi")
+        ));
+
+        // when
+        final boolean hasSamePackages = aUsesStatement.hasSamePackageAs(aPackage);
+
+        // then
+        assertThat(hasSamePackages).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenUsesStatementsPackagesAreDifferent() {
+        // given
+        final String aPackage = "de.friday.filters";
+        final UsesStatement aUsesStatement = new UsesStatement(aMockedUsesStatementContextWith(
+                "de.friday.HelloWorld", aIdentifierTokenFor("HelloWorld")
+        ));
+
+        // when
+        final boolean hasSamePackages = aUsesStatement.hasSamePackageAs(aPackage);
+
+        // when
+        assertThat(hasSamePackages).isFalse();
+    }
+
+    private GosuParser.UsesStatementContext aMockedUsesStatementContextWith(String usesStatement, Token stopToken) {
+        final GosuParser.UsesStatementContext mock = Mockito.mock(GosuParser.UsesStatementContext.class);
+        final GosuParser.NamespaceContext namespaceContextMock = Mockito.mock(GosuParser.NamespaceContext.class);
+
+        Mockito.when(namespaceContextMock.getText()).thenReturn(usesStatement);
+        Mockito.when(mock.namespace()).thenReturn(namespaceContextMock);
+        Mockito.when(mock.getStop()).thenReturn(stopToken);
+
+        return mock;
+    }
+
+    private CommonToken aWildcardToken() {
+        return new CommonToken(GosuLexer.MUL, "*");
+    }
+
+    private CommonToken aIdentifierTokenFor(String className) {
+        return new CommonToken(GosuLexer.IDENTIFIER, className);
+    }
+}

--- a/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
+++ b/src/test/java/de/friday/sonarqube/gosu/plugin/rules/smells/UnnecessaryImportRuleTest.java
@@ -18,8 +18,6 @@ package de.friday.sonarqube.gosu.plugin.rules.smells;
 
 import org.junit.jupiter.api.Test;
 import static de.friday.test.support.rules.dsl.gosu.GosuRuleTestDsl.given;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class UnnecessaryImportRuleTest {
 
@@ -42,23 +40,5 @@ class UnnecessaryImportRuleTest {
         given("UnnecessaryImportRule/nokWithInnerClass.gs")
                 .whenCheckedAgainst(UnnecessaryImportRule.class)
                 .then().issuesFound().hasSizeEqualTo(1);
-    }
-
-    @Test
-    void getClassNameThrowsExceptionWhenNoPackageIsProvided() {
-        //given
-        final UnnecessaryImportRule rule = new UnnecessaryImportRule();
-
-        //when //then
-        assertThatThrownBy(
-                () -> rule.getClassName("JustClassName")
-        ).isInstanceOf(IllegalArgumentException.class).hasMessage("No package found.");
-    }
-
-    @Test
-    void getClassNameReturnsClassNameWhenFullQualifiedClassNameIsProvided() {
-        assertThat(
-                new UnnecessaryImportRule().getClassName("de.friday.claims.SomeClass")
-        ).isEqualTo("SomeClass");
     }
 }

--- a/src/test/resources/rules/UnnecessaryImportRule/nok.gs
+++ b/src/test/resources/rules/UnnecessaryImportRule/nok.gs
@@ -9,6 +9,8 @@ uses checks.nested.UnusedImport
 uses checks.nested.SomethingElse
 uses friday.cc.gdv.GdvInvoiceWrapper
 
+uses de.*
+
 class nok {
 
   function sampleFunc(s: String, i: int, gdvWrapper: GdvInvoiceWrapper): Claim {

--- a/src/test/resources/rules/UnnecessaryImportRule/ok.gs
+++ b/src/test/resources/rules/UnnecessaryImportRule/ok.gs
@@ -8,6 +8,8 @@ uses de.friday.products.ProductCodes
 uses Relop#Equals
 uses ProductCodes#*
 
+uses de.*
+
 class ok {
 
   function sampleFunc() {

--- a/src/testIntegration/java/de/friday/sonarqube/gosu/plugin/SimpleGosuProjectIT.java
+++ b/src/testIntegration/java/de/friday/sonarqube/gosu/plugin/SimpleGosuProjectIT.java
@@ -106,7 +106,7 @@ public class SimpleGosuProjectIT {
                             assertThat(issue.getType()).isEqualTo(Common.RuleType.CODE_SMELL);
                             assertThat(issue.getScope()).isEqualTo("MAIN");
                             assertThat(issue.getSeverity()).isEqualTo(Common.Severity.MINOR);
-                            assertThat(issue.getMessage()).isEqualTo("Unnecessary import, java.lang classes are always available.");
+                            assertThat(issue.getMessage()).isEqualTo("Unnecessary import, Java Classes are always available.");
                         }
                 );
     }

--- a/src/testIntegration/resources/projects/simple-gosu-project/src/main/gosu/de/friday/gosu/simple/FizzBuzz.gs
+++ b/src/testIntegration/resources/projects/simple-gosu-project/src/main/gosu/de/friday/gosu/simple/FizzBuzz.gs
@@ -3,6 +3,8 @@ package de.friday.gosu.simple
 uses java.lang.Boolean
 uses java.lang.Integer
 
+uses java.util.*
+
 class FizzBuzz implements Fizz, Buzz {
 
   function run() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the pull request Title above -->

## Description
<!--- Describe your changes in detail -->
Update `UnnecessaryImportRule` to avoid mapping class names of wildcard imports since the class names are not available for these statements context. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The [simple-gosu-project](https://github.com/FRI-DAY/sonar-gosu-plugin/tree/main/src/testIntegration/resources/projects/simple-gosu-project), used on the integration tests, was updated to cover this scenario.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Gosu Rule (adds a new Gosu rule to the plugin)
- [x] Tech Debt (refactoring, etc.)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (add or update README or docs)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
